### PR TITLE
fix: use raw link for etc labs logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 </p>
 <p align="center">
-<a href="https://etclabs.org">Sponsored by <img alt="Ethereum Classic Lab" src="https://github.com/open-rpc/design/blob/master/png/etc-labs-logo-32x32.png" /> Ethereum Classic Labs</a>.
+<a href="https://etclabs.org">Sponsored by <img alt="Ethereum Classic Lab" src="https://github.com/open-rpc/design/blob/master/png/etc-labs-logo-32x32.png?raw=true" /> Ethereum Classic Labs</a>.
 </p>
 
 # OpenRPC Specification


### PR DESCRIPTION
fixes broken image on sites off of github