### PR TITLE
fix: content descriptor object required default

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ Field Name | Type | Description
 <a name="content-descriptor-name"></a>name | `string` | name of the content that is being described.
 <a name="content-descriptor-summary"></a>summary | `string` | A short summary of what the method does.
 <a name="content-descriptor-description"></a>description | `string` | A verbose explanation of the method behavior. [GitHub Flavored Markdown syntax](https://github.github.com/gfm/) MAY be used for rich text representation.
-<a name="content-descriptor-required"></a>required | `boolean` | Determines if the content is a required field.
+<a name="content-descriptor-required"></a>required | `boolean` | Determines if the content is a required field. Default value is `false`.
 <a name="content-descriptor-schema"></a>schema | [Schema Object](#schema-object) | Schema that describes the content.
 <a name="content-descriptor-examples"></a>examples | [[Example Object](#example-object)] | Examples of the parameter. The examples MUST match the specified schema. If referencing a `schema` which contains (an) example(s), the `examples` value SHALL _override_ the examples provided by the schema. To represent examples of media types that cannot naturally be represented in JSON, a string value can contain the example with escaping where necessary.
 <a name="content-descriptor-deprecated"></a>deprecated | `boolean` | Specifies that the content is deprecated and SHOULD be transitioned out of usage. Default value is `false`.


### PR DESCRIPTION
Defines the default value of the required field on Content Descriptor Object which should be `false`. Resolves https://github.com/open-rpc/spec/issues/86