### PR TITLE
fix: typo

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -182,7 +182,7 @@ This object MAY be extended with [Specification Extensions](#specification-exten
 
 ## Method Object
 
-Describes the interface for the given method name. The method name is used as the `method` field of the JSON-RPC body. It therefor MUST be unique.
+Describes the interface for the given method name. The method name is used as the `method` field of the JSON-RPC body. It therefore MUST be unique.
 
 Field Name | Type | Description
 ---|:---:|---
@@ -197,7 +197,7 @@ Field Name | Type | Description
 <a name="method-servers"></a>servers | [[Server Object](#server-object)] | An alternative `servers` array to service this method. If an alternative `servers` array is specified at the Root level, it will be overridden by this value.
 <a name="method-errors"></a>errors | [[Error Object](#error-object) \| [Reference Object](#reference-object)] | A list of custom application defined errors that MAY be returned. The Errors MUST have unique error codes.
 <a name="method-links"></a>links | [[Link Object](#link-object) \| [Reference Object](#reference-object)] | A list of possible links from this method call.
-<a name="method-param-structure"></a>paramStructure | `"by-name"` \| `"by-position"` | Format the server expects the params. Defaults to `"by-positon"`.
+<a name="method-param-structure"></a>paramStructure | `"by-name"` \| `"by-position"` | Format the server expects the params. Defaults to `"by-position"`.
 <a name="method-examples"></a>examples | [[Example Pairing Object](#example-pairing-object)] | Array of [Example Pairing Object](#example-pairing-object) where each example includes a valid params-to-result [Content Descriptor](#content-descriptor-object) pairing.
 
 This object MAY be extended with [Specification Extensions](#specification-extensions).


### PR DESCRIPTION
- updated _therefor_ to _therefor_**e** to make it more consistent. **therefore** was also used down the text and it looked more modern than only **therefor** (without **e** at the end of the word).
- fixed **position** typo.