### PR TITLE
Fix/version take 4

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -6,7 +6,8 @@
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     "@semantic-release/github",
-    "@semantic-release/git"
+    "@semantic-release/git",
+    "@semantic-release/npm"
   ],
   "verifyConditions": [
     "@semantic-release/changelog",
@@ -16,6 +17,7 @@
   "prepare": [
     "@semantic-release/changelog",
     "@semantic-release/git",
+    "@semantic-release/npm",
     [
       "@semantic-release/exec",
       {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-semantic-release-dev",
   "description": "The OPEN-RPC Specification",
   "main": "index.js",
+  "private": true,
   "scripts": {
     "validate": "node_modules/.bin/mdv ./spec.md ./README.md ./build/markdown/*.md",
     "lint": "./node_modules/.bin/markdownlint ./spec.md ./README.md ./build/markdown/*.md",


### PR DESCRIPTION
the npm plugin is the one that writes the version to package.json - so we only want the prepare step.