### PR TITLE
fix: add note about fallback examples

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -227,7 +227,7 @@ This object MAY be extended with [Specification Extensions](#specification-exten
 
 ### Example Pairing Object
 
-The Example Pairing object consists of a set of example params and result. The result is what you can expect from the JSON-RPC service given the exact params. JSON-Schema examples MAY be used as a fallback for Example Pairings.
+The Example Pairing object consists of a set of example params and result. The result is what you can expect from the JSON-RPC service given the exact params. JSON Schema examples MAY be used as a fallback for Example Pairings.
 
 Field Name | Type | Description
 ---|:---:|---

--- a/spec.md
+++ b/spec.md
@@ -241,7 +241,7 @@ This object MAY be extended with [Specification Extensions](#specification-exten
 
 #### Example Object
 
-The Example object is an object that defines an example that is intended to match the `schema` of a given [Content Descriptor](#content-descriptor-schema). 
+The Example object is an object that defines an example that is intended to match the `schema` of a given [Content Descriptor](#content-descriptor-schema).
 
 Field Name | Type | Description
 ---|:---:|---

--- a/spec.md
+++ b/spec.md
@@ -227,7 +227,7 @@ This object MAY be extended with [Specification Extensions](#specification-exten
 
 ### Example Pairing Object
 
-The Example Pairing object consists of a set of example params and result. The result is what you can expect from the JSON-RPC service given the exact params.
+The Example Pairing object consists of a set of example params and result. The result is what you can expect from the JSON-RPC service given the exact params. JSON-Schema examples MAY be used as a fallback for Example Pairings.
 
 Field Name | Type | Description
 ---|:---:|---
@@ -241,7 +241,7 @@ This object MAY be extended with [Specification Extensions](#specification-exten
 
 #### Example Object
 
-The Example object is an object that defines an example that is intended to match the `schema` of a given [Content Descriptor](#content-descriptor-schema).
+The Example object is an object that defines an example that is intended to match the `schema` of a given [Content Descriptor](#content-descriptor-schema). 
 
 Field Name | Type | Description
 ---|:---:|---


### PR DESCRIPTION
I think this is kind of what https://github.com/open-rpc/spec/issues/315 was trying to say. But we should allow for using `schema.examples` as a fallback. I have a PR up for schema utils to support this in `parseOpenRPCDocument`: https://github.com/open-rpc/schema-utils-js/pull/486