### PR TITLE
fix: add a note about examplePairingObject.result being undefined

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -236,7 +236,7 @@ Field Name | Type | Description
 <a name="example-pairing-description"></a>description | `string` | A verbose explanation of the example pairing.
 <a name="example-pairing-summary"></a>summary | `string` | Short description for the example pairing.
 <a name="example-pairing-params"></a>params | [[Example Object](#example-object) \| [Reference Object](#reference-object)] | Example parameters.
-<a name="example-result"></a>result | [Example Object](#example-object) \| [Reference Object](#reference-object) | Example result.
+<a name="example-result"></a>result | [Example Object](#example-object) \| [Reference Object](#reference-object) | Example result. When undefined, the example pairing represents usage of the method as a notification.
 
 This object MAY be extended with [Specification Extensions](#specification-extensions).
 


### PR DESCRIPTION
fixes #373