### PR TITLE
feat: validate json code blocks during tests

### DIFF
--- a/bin/validate-json.js
+++ b/bin/validate-json.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+const fs = require('fs');
+
+const files = process.argv.slice(2);
+let hadError = false;
+
+files.forEach((file) => {
+  const content = fs.readFileSync(file, 'utf8');
+  const regex = /```json\n([\s\S]*?)```/gm;
+  let match;
+  while ((match = regex.exec(content)) !== null) {
+    try {
+      JSON.parse(match[1]);
+    } catch (err) {
+      console.error(`Invalid JSON in ${file}: ${err.message}`);
+      hadError = true;
+    }
+  }
+});
+
+if (hadError) {
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "private": true,
   "scripts": {
     "validate": "node_modules/.bin/mdv ./spec.md ./README.md ./build/markdown/*.md",
+    "validate:json": "./bin/validate-json.js ./spec.md",
     "lint": "./node_modules/.bin/markdownlint ./spec.md ./README.md ./build/markdown/*.md",
     "build": "./bin/build.sh",
-    "test": "npm run build && npm run validate && npm run lint"
+    "test": "npm run build && npm run validate && npm run lint && npm run validate:json"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- add script to parse JSON code blocks and verify syntax
- run JSON validation when executing `npm test`

## Testing
- `npm run validate:json`
- `npm test` *(fails: request to https://api.github.com/... ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68b3dd518b80832f83141ca67719f09a