### PR TITLE
chore: prepare release 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.4.1 (2026-02-25)
+
+### Fixes
+
+- the pattern for the 1.4 regex ([`e51ee78`](https://github.com/open-rpc/spec/commit/e51ee78))
+
 ## 1.4.0 (2026-02-24)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-rpc/spec",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "The OPEN-RPC Specification",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Merging this PR will create a new release

## Fixes

- the pattern for the 1.4 regex ([`e51ee78`](https://github.com/open-rpc/spec/commit/e51ee78))